### PR TITLE
Fixes JDK 9 warning: Illegal reflective access by com.google.protobuf.UnsafeUtil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 sudo: false
 
 jdk:
-- oraclejdk8
+- oraclejdk9
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.7",
-  "com.github.os72"        %  "protoc-jar"     % "3.7.0.1",
+  "com.google.protobuf"    % "protobuf-java"  % "3.8.0",
+  "com.github.os72"        %  "protoc-jar"     % "3.8.0",
   "com.typesafe"           %  "config"         % "1.3.4",
   "com.github.pureconfig"  %% "pureconfig"     % "0.10.2" excludeAll(ExclusionRule(organization = "com.typesafe", name = "config")),
   "org.scalatest"          %% "scalatest"      % "3.0.7" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.7",
-  "com.google.protobuf"    % "protobuf-java"  % "3.8.0",
+  "com.google.protobuf"    %  "protobuf-java"  % "3.8.0",
   "com.github.os72"        %  "protoc-jar"     % "3.8.0",
   "com.typesafe"           %  "config"         % "1.3.4",
   "com.github.pureconfig"  %% "pureconfig"     % "0.10.2" excludeAll(ExclusionRule(organization = "com.typesafe", name = "config")),


### PR DESCRIPTION
Update to latest protobuf 3.8.0 version java libs

Details are in protocolbuffers/protobuf#3781
Fixes warning
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/home/user/experimental/protoc-gen-uml/target/universal/stage/lib/com.google.protobuf.protobuf-java-3.4.0.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release